### PR TITLE
ec_encoder_async: Add multiple encoder threads

### DIFF
--- a/ec_encode_example/Makefile
+++ b/ec_encode_example/Makefile
@@ -3,8 +3,8 @@ PREFIX = /usr
 sbindir = bin
 
 CC = gcc
-CFLAGS += -g -ggdb -Wall -W -D_GNU_SOURCE
-LDFLAGS = -Wl,-rpath,/usr/lib -libverbs -lgf_complete -lJerasure -lpthread -lrdmacm
+CFLAGS += -g -ggdb -Wall -W -D_GNU_SOURCE -pthread
+LDFLAGS = -Wl,-rpath,/usr/lib -libverbs -lgf_complete -lJerasure -lpthread -lrdmacm -pthread
 
 OBJECTS_LAT = ec_encoder_async.o ec_perf_async.o ec_perf_sync.o ec_encoder.o ec_decoder.o ec_updater.o ec_common.o common.o 
 TARGETS = ibv_ec_encoder_async ibv_ec_perf_async ibv_ec_perf_sync ibv_ec_encoder ibv_ec_decoder ibv_ec_updater 

--- a/ec_encode_example/common.c
+++ b/ec_encode_example/common.c
@@ -59,6 +59,7 @@ int common_process_inargs(int argc, char *argv[],
     in->sw = 0;
     in->polling = 0;
     in->in_memory = 0;
+    in->threads = 1;
 
     while (1) {
         int c, ret;
@@ -186,6 +187,14 @@ int common_process_inargs(int argc, char *argv[],
         case 'l':
             in->max_inflight_calcs = strtol(optarg, NULL, 0);
             if (in->max_inflight_calcs < 1) {
+                usage(argv[0]);
+                return -EINVAL;
+            }
+            break;
+
+        case 't':
+            in->threads = strtol(optarg, NULL, 0);
+            if (in->threads < 1) {
                 usage(argv[0]);
                 return -EINVAL;
             }

--- a/ec_encode_example/common.h
+++ b/ec_encode_example/common.h
@@ -74,6 +74,7 @@ struct inargs {
     char    *data_updates;
     char    *code_updates;
     int     in_memory;
+    int     threads;
 };
 
 extern struct sockaddr_storage ssin;


### PR DESCRIPTION
Number of encoder threads is defined by '-t' command line
parameter. Default number of threads is 1.  Each encoder thread
allocates private encoding context, encodes the whole input file and
saves result in the output code file with thread index as a
suffix. e.g. 'sample.code.offload.5'.

Signed-off-by: Evgeniy Kochetov <evgeniik@mellanox.com>