### PR TITLE
fix command error while using -r or -a parameter

### DIFF
--- a/dv_signature_offload_api_example/sig_example.c
+++ b/dv_signature_offload_api_example/sig_example.c
@@ -2095,7 +2095,9 @@ int main(int argc, char *argv[])
 	}
 
 	if ((config.corrupt_app_tag || config.corrupt_ref_tag) &&
-	    (strcmp("t10dif", config.sig->name))) {
+	    strcmp("t10dif-type1", config.sig->name) &&
+	    strcmp("t10dif-type2", config.sig->name) &&
+	    strcmp("t10dif-type3", config.sig->name)) {
 		usage(argv[0]);
 		return 1;
 	}


### PR DESCRIPTION
sig name for t10dif has been changed to t10dif-type1/t10dif-type2/t10dif-type3, which  has to be updated while comparing sig name.